### PR TITLE
batocera-usbmount: replace sequential number with random ones

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-usbmount
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-usbmount
@@ -22,8 +22,7 @@ fi
 # it will be played by the S11share script after the mounting of /userdata
 if mkdir -p /var/run/usbmount.delay
 then
-    N=$(ls /var/run/usbmount.delay | wc -l)
-    N=$((N+1))
+    N=`/usr/bin/shuf -i 1-1000000 -n 1`
     set |
 	grep -E '^DEVNAME=|^ID_FS_USAGE=|^ID_FS_UUID=|^ID_FS_TYPE=|^ID_FS_LABEL=' |
 	sed -e s+'^'+'export '+ > /var/run/usbmount.delay/"$N"."$1"


### PR DESCRIPTION
There is an issue where an SD card that has been updated on another computer fails to mount https://discord.com/channels/1173228527605272666/1173228528054054985/1307348511527800923

This happens because udev triggers are executed in parallel, but the code that is executed (/usr/bin/batocera-usbmount) expects to be executed sequentially. The intended behaviour is that one file is created for each delayed partition in /var/run/usbmount.delay/, and these are executed later by /etc/init.d/S11share. This fails because, when executed in parallel, the files overwrite one another (e.g. several files are written called /var/run/usbmount.delay/5.add). As a result, not all the files are present when /etc/init.d/S11share is run, and some files may be corrupted. This causes missing or failed mounts.

This commit fixes the problem by using large random numbers instead of sequential ones. This makes it very unlikely that any of the files will get overwritten.